### PR TITLE
fix version backbone, wreqr, jquery-minicolors and merge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,15 +51,14 @@
             "coffee-script": "~1.9.1",
             "load-grunt-tasks": "~3.2.0",
             "glob": "~5.0.10",
-            "merge": "*"
+            "merge": "~1.2.0"
         },
         "expose-npm-packages": true,
         "require-bower": {
             "jquery": "~2.1.1",
             "jquery-ui": "~1.11.2",
-            "backbone": "*",
-            "underscore": "*",
-            "backbone.wreqr": "*",
+            "backbone": "~1.2.3",
+            "backbone.wreqr": "~1.3.5",
             "Jcrop": "~0.9.12",
             "flow.js": "~2.9.0"
         }


### PR DESCRIPTION
[OO-CONFIGURATION] dependencies version are fixed : `merge ~1.2.0`, `backbone ~1.2.3`, `backbone.wreqr ~1.3.5`.
[OO-CONFIGURATION] bower dependency `underscore` is removed, this package is include by `backbone`
