### PR TITLE
Move getCacheTags from AbstractStrategy to implementing strategies

### DIFF
--- a/MediaAdminBundle/DisplayBlock/Strategies/DisplayMediaStrategy.php
+++ b/MediaAdminBundle/DisplayBlock/Strategies/DisplayMediaStrategy.php
@@ -42,6 +42,16 @@ class DisplayMediaStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/MediaAdminBundle/DisplayBlock/Strategies/GalleryStrategy.php
+++ b/MediaAdminBundle/DisplayBlock/Strategies/GalleryStrategy.php
@@ -37,6 +37,16 @@ class GalleryStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/MediaAdminBundle/DisplayBlock/Strategies/MediaListByKeywordStrategy.php
+++ b/MediaAdminBundle/DisplayBlock/Strategies/MediaListByKeywordStrategy.php
@@ -44,6 +44,16 @@ class MediaListByKeywordStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string

--- a/MediaAdminBundle/DisplayBlock/Strategies/SlideshowStrategy.php
+++ b/MediaAdminBundle/DisplayBlock/Strategies/SlideshowStrategy.php
@@ -37,6 +37,16 @@ class SlideshowStrategy extends AbstractStrategy
     }
 
     /**
+     * @param ReadBlockInterface $block
+     *
+     * @return Array
+     */
+    public function getCacheTags(ReadBlockInterface $block)
+    {
+        return array();
+    }
+
+    /**
      * Get the name of the strategy
      *
      * @return string


### PR DESCRIPTION
[OO-BCBREAK] DisplayBundle/DisplayBlock/Strategies/AbstractStrategy:getCacheTags() is now abstract and must therefore be explicitally implemented on each display strategy
https://github.com/open-orchestra/open-orchestra-display-bundle/pull/200
https://github.com/open-orchestra/open-orchestra-media-bundle/pull/166
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/17
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/18
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/159
https://github.com/open-orchestra/open-orchestra-user-bundle/pull/92
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1457
