### PR TITLE
fix cloned save button

### DIFF
--- a/MediaAdminBundle/Resources/public/coffee/view/AlternativeSelectView.coffee
+++ b/MediaAdminBundle/Resources/public/coffee/view/AlternativeSelectView.coffee
@@ -33,7 +33,7 @@ AlternativeSelectView = OrchestraView.extend(
     path = @getPath()
     path.push @options.mediaName
     $('.js-widget-title', @options.domContainer).html path.join(' > ')
-    OpenOrchestra.RibbonButton.ribbonFormButtonView.resetAll('.modal-form-button')
+    OpenOrchestra.RibbonButton.ribbonFormButtonModalView.resetAll('.modal-form-button')
 
   changeCropFormat: (event) ->
     format = $(event.currentTarget).val()

--- a/MediaAdminBundle/Resources/public/coffee/view/CropFormView.coffee
+++ b/MediaAdminBundle/Resources/public/coffee/view/CropFormView.coffee
@@ -27,7 +27,7 @@ CropFormView = OrchestraView.extend(
     if !@options.isModal
       OpenOrchestra.RibbonButton.ribbonFormButtonView.setFocusedView @, '.ribbon-form-button'
     else
-      OpenOrchestra.RibbonButton.ribbonFormButtonView.setFocusedView @, '.modal-form-button'
+      OpenOrchestra.RibbonButton.ribbonFormButtonModalView.setFocusedView @, '.modal-form-button'
 
   initCrop: ->
     currentView = @

--- a/MediaAdminBundle/Resources/public/coffee/view/GalleryCollectionView.coffee
+++ b/MediaAdminBundle/Resources/public/coffee/view/GalleryCollectionView.coffee
@@ -41,7 +41,7 @@ GalleryCollectionView = OrchestraView.extend(
       OpenOrchestra.RibbonButton.ribbonFormButtonView.setFocusedView @, '.ribbon-form-button'
     else
       $('.js-widget-title', @options.domContainer).text @getPath().join(' > ')
-      OpenOrchestra.RibbonButton.ribbonFormButtonView.setFocusedView @, '.modal-form-button'
+      OpenOrchestra.RibbonButton.ribbonFormButtonModalView.setFocusedView @, '.modal-form-button'
     @addFilterWidget()
     @renderCollection()
 

--- a/MediaAdminBundle/Resources/public/coffee/view/MediaUploadView.coffee
+++ b/MediaAdminBundle/Resources/public/coffee/view/MediaUploadView.coffee
@@ -28,7 +28,7 @@ MediaUploadView = OrchestraView.extend(
     if !@options.isModal
       OpenOrchestra.RibbonButton.ribbonFormButtonView.setFocusedView @, '.ribbon-form-button'
     else
-      OpenOrchestra.RibbonButton.ribbonFormButtonView.setFocusedView @, '.modal-form-button'
+      OpenOrchestra.RibbonButton.ribbonFormButtonModalView.setFocusedView @, '.modal-form-button'
     $('.js-widget-title', @options.domContainer).html @options.title
     @renderSubmitFile()
     return


### PR DESCRIPTION
If a page contains a cloned button  we can not click this button after open a modal which contains a cloned button because the page loses focus. this PR fix that by using two instances: one for normal page and an other for modal page
