### PR TITLE
Fix broken media with no alternative selection

### DIFF
--- a/MediaAdminBundle/Resources/public/coffee/view/GalleryView.coffee
+++ b/MediaAdminBundle/Resources/public/coffee/view/GalleryView.coffee
@@ -97,7 +97,7 @@ GalleryView = OrchestraView.extend(
   sendMedia: ->
     modalContainer = @$el.closest('.mediaModalContainer')
     intputName = modalContainer.data('input')
-    $('#' + intputName).val @options.media.id
+    $('#' + intputName + '_id').val @options.media.id
     $('#previewImage_' + intputName).attr 'src', @$el.find('.superbox-img img').attr('src')
     modalContainer.find('.mediaModalClose').click()
 )


### PR DESCRIPTION
[OO-BUGFIX] In a content, the selection of a media with no alternative is now correctly stored 
