### PR TITLE
invalidate tag of content and node when update used media

### DIFF
--- a/MediaAdminBundle/EventSubscriber/MediaCacheInvalidateSubscriber.php
+++ b/MediaAdminBundle/EventSubscriber/MediaCacheInvalidateSubscriber.php
@@ -41,7 +41,7 @@ class MediaCacheInvalidateSubscriber implements EventSubscriberInterface
      */
     protected function invalidate($media)
     {
-        $tags = $this->extractReferenceManager->getInvalidateTagStatusableElement($media->getUsageReference());
+        $tags = $this->extractReferenceManager->getStatusableElementCacheTag($media->getUsageReference());
         $tags[] = $this->tagManager->formatMediaIdTag($media->getId());
         $this->cacheableManager->invalidateTags($tags);
     }

--- a/MediaAdminBundle/EventSubscriber/MediaCacheInvalidateSubscriber.php
+++ b/MediaAdminBundle/EventSubscriber/MediaCacheInvalidateSubscriber.php
@@ -2,6 +2,8 @@
 
 namespace OpenOrchestra\MediaAdminBundle\EventSubscriber;
 
+use OpenOrchestra\Media\Model\MediaInterface;
+use OpenOrchestra\MediaAdminBundle\ExtractReference\ExtractReferenceManager;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use OpenOrchestra\MediaAdmin\MediaEvents;
 use OpenOrchestra\MediaAdmin\Event\MediaEvent;
@@ -15,27 +17,33 @@ class MediaCacheInvalidateSubscriber implements EventSubscriberInterface
 {
     protected $cacheableManager;
     protected $tagManager;
+    protected $extractReferenceManager;
 
     /**
-     * @param CacheableManager $cacheableManager
-     * @param TagManager       $tagManager
+     * @param CacheableManager        $cacheableManager
+     * @param TagManager              $tagManager
+     * @param ExtractReferenceManager $extractReferenceManager
      */
-    public function __construct(CacheableManager $cacheableManager, TagManager $tagManager)
-    {
+    public function __construct(
+        CacheableManager $cacheableManager,
+        TagManager $tagManager,
+        ExtractReferenceManager $extractReferenceManager
+    ) {
         $this->cacheableManager = $cacheableManager;
         $this->tagManager = $tagManager;
+        $this->extractReferenceManager = $extractReferenceManager;
     }
 
     /**
      * Invalidate cache on $mediaId
      * 
-     * @param string $mediaId
+     * @param MediaInterface $media
      */
-    protected function invalidate($mediaId)
+    protected function invalidate($media)
     {
-        $this->cacheableManager->invalidateTags(array(
-            $this->tagManager->formatMediaIdTag($mediaId)
-        ));
+        $tags = $this->extractReferenceManager->getInvalidateTagStatusableElement($media->getUsageReference());
+        $tags[] = $this->tagManager->formatMediaIdTag($media->getId());
+        $this->cacheableManager->invalidateTags($tags);
     }
 
     /**
@@ -45,7 +53,7 @@ class MediaCacheInvalidateSubscriber implements EventSubscriberInterface
      */
     public function updateMedia(MediaEvent $event)
     {
-        $this->invalidate($event->getMedia()->getId());
+        $this->invalidate($event->getMedia());
     }
 
     /**
@@ -55,7 +63,7 @@ class MediaCacheInvalidateSubscriber implements EventSubscriberInterface
      */
     public function deleteMedia(MediaEvent $event)
     {
-        $this->invalidate($event->getMedia()->getId());
+        $this->invalidate($event->getMedia());
     }
 
     /**

--- a/MediaAdminBundle/ExtractReference/ExtractReferenceInterface.php
+++ b/MediaAdminBundle/ExtractReference/ExtractReferenceInterface.php
@@ -17,6 +17,13 @@ interface ExtractReferenceInterface
     public function support(StatusableInterface $statusableElement);
 
     /**
+     * @param string $reference
+     *
+     * @return bool
+     */
+    public function supportReference($reference);
+
+    /**
      * @param StatusableInterface $statusableElement
      *
      * @return array
@@ -31,6 +38,15 @@ interface ExtractReferenceInterface
      * return string
      */
     public function getReferencePattern($statusableElementId);
+
+    /**
+     * Get invalidate tag of statusable element for reference
+     *
+     * @param string $reference
+     *
+     * @return string|null
+     */
+    public function getInvalidateTagStatusableElement($reference);
 
     /**
      * @return string

--- a/MediaAdminBundle/ExtractReference/ExtractReferenceInterface.php
+++ b/MediaAdminBundle/ExtractReference/ExtractReferenceInterface.php
@@ -40,13 +40,13 @@ interface ExtractReferenceInterface
     public function getReferencePattern($statusableElementId);
 
     /**
-     * Get invalidate tag of statusable element for reference
+     * Get cache tag of statusable element for reference
      *
      * @param string $reference
      *
      * @return string|null
      */
-    public function getInvalidateTagStatusableElement($reference);
+    public function getStatusableElementCacheTag($reference);
 
     /**
      * @return string

--- a/MediaAdminBundle/ExtractReference/ExtractReferenceManager.php
+++ b/MediaAdminBundle/ExtractReference/ExtractReferenceManager.php
@@ -59,4 +59,29 @@ class ExtractReferenceManager
 
         throw new ExtractReferenceStrategyNotFound();
     }
+
+    /**
+     * Get invalidate tag of references
+     *
+     * @param array $references
+     *
+     * @return array
+     */
+    public function getInvalidateTagStatusableElement(array $references)
+    {
+        $invalidateTag = array();
+        /** @var ExtractReferenceInterface $strategy */
+        foreach ($references as $reference) {
+            foreach ($this->strategies as $strategy) {
+                if ($strategy->supportReference($reference)) {
+                    $tag = $strategy->getInvalidateTagStatusableElement($reference);
+                    if (null !== $tag) {
+                        $invalidateTag[] = $tag;
+                    }
+                }
+            }
+        }
+
+        return $invalidateTag;
+    }
 }

--- a/MediaAdminBundle/ExtractReference/ExtractReferenceManager.php
+++ b/MediaAdminBundle/ExtractReference/ExtractReferenceManager.php
@@ -61,20 +61,20 @@ class ExtractReferenceManager
     }
 
     /**
-     * Get invalidate tag of references
+     * Get cache tag of references
      *
      * @param array $references
      *
      * @return array
      */
-    public function getInvalidateTagStatusableElement(array $references)
+    public function getStatusableElementCacheTag(array $references)
     {
         $invalidateTag = array();
         /** @var ExtractReferenceInterface $strategy */
         foreach ($references as $reference) {
             foreach ($this->strategies as $strategy) {
                 if ($strategy->supportReference($reference)) {
-                    $tag = $strategy->getInvalidateTagStatusableElement($reference);
+                    $tag = $strategy->getStatusableElementCacheTag($reference);
                     if (null !== $tag) {
                         $invalidateTag[] = $tag;
                     }

--- a/MediaAdminBundle/ExtractReference/Strategies/AbstractExtractReferenceStrategy.php
+++ b/MediaAdminBundle/ExtractReference/Strategies/AbstractExtractReferenceStrategy.php
@@ -2,6 +2,7 @@
 
 namespace OpenOrchestra\MediaAdminBundle\ExtractReference\Strategies;
 
+use OpenOrchestra\BaseBundle\Manager\TagManager;
 use OpenOrchestra\BBcodeBundle\ElementNode\BBcodeElementNode;
 use OpenOrchestra\BBcodeBundle\Parser\BBcodeParserInterface;
 use OpenOrchestra\Media\BBcode\AbstractMediaCodeDefinition;
@@ -14,13 +15,16 @@ use OpenOrchestra\ModelInterface\Model\StatusableInterface;
 abstract class AbstractExtractReferenceStrategy implements ExtractReferenceInterface
 {
     protected $bbcodeParser;
+    protected $tagManager;
 
     /**
      * @param BBcodeParserInterface $bbCoderParser
+     * @param TagManager            $tagManager
      */
-    public function __construct(BBcodeParserInterface $bbCoderParser)
+    public function __construct(BBcodeParserInterface $bbCoderParser, TagManager $tagManager)
     {
         $this->bbcodeParser = $bbCoderParser;
+        $this->tagManager = $tagManager;
     }
 
     /**
@@ -31,7 +35,7 @@ abstract class AbstractExtractReferenceStrategy implements ExtractReferenceInter
     abstract public function support(StatusableInterface $statusableElement);
 
     /**
-     * @param StatusableInterface|NodeInterface $statusableElement
+     * @param StatusableInterface $statusableElement
      *
      * @return array
      */

--- a/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromContentStrategy.php
+++ b/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromContentStrategy.php
@@ -79,13 +79,13 @@ class ExtractReferenceFromContentStrategy extends AbstractExtractReferenceStrate
     }
 
     /**
-     * Get invalidate tag of statusable element for reference
+     * Get cache tag of statusable element for reference
      *
      * @param string $reference
      *
      * @return string|null
      */
-    public function getInvalidateTagStatusableElement($reference)
+    public function getStatusableElementCacheTag($reference)
     {
         $id = preg_replace('/^'. self::REFERENCE_PREFIX .'/', '', $reference);
         $content = $this->contentRepository->findById($id);

--- a/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromContentStrategy.php
+++ b/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromContentStrategy.php
@@ -2,9 +2,12 @@
 
 namespace OpenOrchestra\MediaAdminBundle\ExtractReference\Strategies;
 
+use OpenOrchestra\BaseBundle\Manager\TagManager;
+use OpenOrchestra\BBcodeBundle\Parser\BBcodeParserInterface;
 use OpenOrchestra\ModelInterface\Model\ContentAttributeInterface;
 use OpenOrchestra\ModelInterface\Model\ContentInterface;
 use OpenOrchestra\ModelInterface\Model\StatusableInterface;
+use OpenOrchestra\ModelInterface\Repository\ContentRepositoryInterface;
 
 /**
  * Class ExtractReferenceFromContentStrategy
@@ -12,6 +15,19 @@ use OpenOrchestra\ModelInterface\Model\StatusableInterface;
 class ExtractReferenceFromContentStrategy extends AbstractExtractReferenceStrategy
 {
     const REFERENCE_PREFIX = 'content-';
+
+    protected $contentRepository;
+
+    /**
+     * @param BBcodeParserInterface      $bbCoderParser
+     * @param TagManager                 $tagManager
+     * @param ContentRepositoryInterface $contentRepository
+     */
+    public function __construct(BBcodeParserInterface $bbCoderParser, TagManager $tagManager, ContentRepositoryInterface $contentRepository)
+    {
+        parent::__construct($bbCoderParser, $tagManager);
+        $this->contentRepository = $contentRepository;
+    }
 
     /**
      * @param StatusableInterface $statusableElement
@@ -21,6 +37,16 @@ class ExtractReferenceFromContentStrategy extends AbstractExtractReferenceStrate
     public function support(StatusableInterface $statusableElement)
     {
         return $statusableElement instanceof ContentInterface;
+    }
+
+    /**
+     * @param string $reference
+     *
+     * @return bool
+     */
+    public function supportReference($reference)
+    {
+        return strpos($reference, self::REFERENCE_PREFIX) === 0;
     }
 
     /**
@@ -50,6 +76,25 @@ class ExtractReferenceFromContentStrategy extends AbstractExtractReferenceStrate
     public function getReferencePattern($statusableElementId)
     {
         return self::REFERENCE_PREFIX . $statusableElementId;
+    }
+
+    /**
+     * Get invalidate tag of statusable element for reference
+     *
+     * @param string $reference
+     *
+     * @return string|null
+     */
+    public function getInvalidateTagStatusableElement($reference)
+    {
+        $id = preg_replace('/^'. self::REFERENCE_PREFIX .'/', '', $reference);
+        $content = $this->contentRepository->findById($id);
+
+        if (null !== $content) {
+            return $this->tagManager->formatContentIdTag($content->getContentId());
+        }
+
+        return null;
     }
 
     /**

--- a/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromNodeStrategy.php
+++ b/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromNodeStrategy.php
@@ -2,9 +2,12 @@
 
 namespace OpenOrchestra\MediaAdminBundle\ExtractReference\Strategies;
 
+use OpenOrchestra\BaseBundle\Manager\TagManager;
+use OpenOrchestra\BBcodeBundle\Parser\BBcodeParserInterface;
 use OpenOrchestra\ModelInterface\Model\BlockInterface;
 use OpenOrchestra\ModelInterface\Model\NodeInterface;
 use OpenOrchestra\ModelInterface\Model\StatusableInterface;
+use OpenOrchestra\ModelInterface\Repository\NodeRepositoryInterface;
 
 /**
  * Class ExtractReferenceFromNodeStrategy
@@ -12,6 +15,19 @@ use OpenOrchestra\ModelInterface\Model\StatusableInterface;
 class ExtractReferenceFromNodeStrategy extends AbstractExtractReferenceStrategy
 {
     const REFERENCE_PREFIX = 'node-';
+
+    protected $nodeRepository;
+
+    /**
+     * @param BBcodeParserInterface   $bbCoderParser
+     * @param TagManager              $tagManager
+     * @param NodeRepositoryInterface $nodeRepository
+     */
+    public function __construct(BBcodeParserInterface $bbCoderParser, TagManager $tagManager, NodeRepositoryInterface $nodeRepository)
+    {
+        parent::__construct($bbCoderParser, $tagManager);
+        $this->nodeRepository = $nodeRepository;
+    }
 
     /**
      * @param StatusableInterface $statusableElement
@@ -21,6 +37,16 @@ class ExtractReferenceFromNodeStrategy extends AbstractExtractReferenceStrategy
     public function support(StatusableInterface $statusableElement)
     {
         return $statusableElement instanceof NodeInterface;
+    }
+
+    /**
+     * @param string $reference
+     *
+     * @return bool
+     */
+    public function supportReference($reference)
+    {
+        return strpos($reference, self::REFERENCE_PREFIX) === 0;
     }
 
     /**
@@ -50,6 +76,25 @@ class ExtractReferenceFromNodeStrategy extends AbstractExtractReferenceStrategy
     public function getReferencePattern($statusableElementId)
     {
         return self::REFERENCE_PREFIX . $statusableElementId . '-';
+    }
+
+    /**
+     * Get invalidate tag of statusable element for reference
+     *
+     * @param string $reference
+     *
+     * @return string|null
+     */
+    public function getInvalidateTagStatusableElement($reference)
+    {
+        $id = preg_replace('/^'. self::REFERENCE_PREFIX .'/', '', $reference);
+        $id = preg_replace('/-[0-9]*$/', '', $id);
+        $node = $this->nodeRepository->findVersionByDocumentId($id);
+        if (null !== $node) {
+            return $this->tagManager->formatNodeIdTag($node->getNodeId());
+        }
+
+        return null;
     }
 
     /**

--- a/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromNodeStrategy.php
+++ b/MediaAdminBundle/ExtractReference/Strategies/ExtractReferenceFromNodeStrategy.php
@@ -79,13 +79,13 @@ class ExtractReferenceFromNodeStrategy extends AbstractExtractReferenceStrategy
     }
 
     /**
-     * Get invalidate tag of statusable element for reference
+     * Get cache tag of statusable element for reference
      *
      * @param string $reference
      *
      * @return string|null
      */
-    public function getInvalidateTagStatusableElement($reference)
+    public function getStatusableElementCacheTag($reference)
     {
         $id = preg_replace('/^'. self::REFERENCE_PREFIX .'/', '', $reference);
         $id = preg_replace('/-[0-9]*$/', '', $id);

--- a/MediaAdminBundle/Resources/config/extract_reference.yml
+++ b/MediaAdminBundle/Resources/config/extract_reference.yml
@@ -10,12 +10,16 @@ services:
         class: '%open_orchestra_media_admin.extract_reference.node.class%'
         arguments:
           - '@open_orchestra_bbcode.parser'
+          - '@open_orchestra_base.manager.tag'
+          - '@open_orchestra_model.repository.node'
         tags:
             - { name: open_orchestra_media_admin.extract_reference.strategy }
     open_orchestra_media_admin.extract_reference.content:
         class: '%open_orchestra_media_admin.extract_reference.content.class%'
         arguments:
           - '@open_orchestra_bbcode.parser'
+          - '@open_orchestra_base.manager.tag'
+          - '@open_orchestra_model.repository.content'
         tags:
             - { name: open_orchestra_media_admin.extract_reference.strategy }
 

--- a/MediaAdminBundle/Resources/config/subscriber.yml
+++ b/MediaAdminBundle/Resources/config/subscriber.yml
@@ -21,6 +21,7 @@ services:
         arguments:
             - '@open_orchestra_display.manager.cacheable'
             - '@open_orchestra_base.manager.tag'
+            - '@open_orchestra_media_admin.extract_reference_manager'
         tags:
             - { name: kernel.event_subscriber }
     open_orchestra_log.subscriber.media:

--- a/MediaAdminBundle/Tests/EventSubscriber/MediaCacheInvalidateSubscriberTest.php
+++ b/MediaAdminBundle/Tests/EventSubscriber/MediaCacheInvalidateSubscriberTest.php
@@ -18,6 +18,7 @@ class MediaCacheInvalidateSubscriberTest extends AbstractBaseTestCase
     protected $event;
     protected $media;
     protected $mediaId = 'mediaId';
+    protected $extractReferenceManager;
 
     /**
      * Set up the test
@@ -27,11 +28,13 @@ class MediaCacheInvalidateSubscriberTest extends AbstractBaseTestCase
         $this->tagManager = Phake::mock('OpenOrchestra\BaseBundle\Manager\TagManager');
 
         $this->cacheableManager = Phake::mock('OpenOrchestra\DisplayBundle\Manager\CacheableManager');
+        $this->extractReferenceManager = Phake::mock('OpenOrchestra\MediaAdminBundle\ExtractReference\ExtractReferenceManager');
 
-        $this->subscriber = new MediaCacheInvalidateSubscriber($this->cacheableManager, $this->tagManager);
+        $this->subscriber = new MediaCacheInvalidateSubscriber($this->cacheableManager, $this->tagManager, $this->extractReferenceManager);
 
         $this->media = Phake::mock('OpenOrchestra\Media\Model\MediaInterface');
         Phake::when($this->media)->getId()->thenReturn($this->mediaId);
+        Phake::when($this->media)->getUsageReference()->thenReturn(array());
 
         $this->event = Phake::mock('OpenOrchestra\MediaAdmin\Event\MediaEvent');
         Phake::when($this->event)->getMedia()->thenReturn($this->media);

--- a/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromContentStrategyTest.php
+++ b/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromContentStrategyTest.php
@@ -141,11 +141,11 @@ class ExtractReferenceFromContentStrategyTest extends AbstractBaseTestCase
      *
      * @dataProvider provideReferenceAndContent
      */
-    public function testInvalidateTagStatusableElement($reference, $content, $countTagManager, $expectedId)
+    public function testGetStatusableElementCacheTag($reference, $content, $countTagManager, $expectedId)
     {
         Phake::when($this->contentRepository)->findById(Phake::anyParameters())->thenReturn($content);
 
-        $this->strategy->getInvalidateTagStatusableElement($reference);
+        $this->strategy->getStatusableElementCacheTag($reference);
 
         Phake::verify($this->tagManager, Phake::times($countTagManager))->formatContentIdTag($expectedId);
     }

--- a/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromContentStrategyTest.php
+++ b/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromContentStrategyTest.php
@@ -16,8 +16,9 @@ class ExtractReferenceFromContentStrategyTest extends AbstractBaseTestCase
      * @var ExtractReferenceFromContentStrategy
      */
     protected $strategy;
-
     protected $parserBBcode;
+    protected $contentRepository;
+    protected $tagManager;
 
     /**
      * Set up the test
@@ -27,7 +28,10 @@ class ExtractReferenceFromContentStrategyTest extends AbstractBaseTestCase
         $this->parserBBcode = Phake::mock('OpenOrchestra\BBcodeBundle\Parser\BBcodeParserInterface');
         Phake::when($this->parserBBcode)->parse(Phake::anyParameters())->thenReturn($this->parserBBcode);
 
-        $this->strategy = new ExtractReferenceFromContentStrategy($this->parserBBcode);
+        $this->tagManager = Phake::mock('OpenOrchestra\BaseBundle\Manager\TagManager');
+        $this->contentRepository = Phake::mock('OpenOrchestra\ModelInterface\Repository\ContentRepositoryInterface');
+
+        $this->strategy = new ExtractReferenceFromContentStrategy($this->parserBBcode, $this->tagManager, $this->contentRepository);
     }
 
     /**
@@ -70,6 +74,31 @@ class ExtractReferenceFromContentStrategyTest extends AbstractBaseTestCase
     }
 
     /**
+     * @param string $reference
+     * @param bool   $support
+     *
+     * @dataProvider provideReferenceAndSupport
+     */
+    public function testSupportReference($reference, $support)
+    {
+        $this->assertSame($support, $this->strategy->supportReference($reference));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideReferenceAndSupport()
+    {
+        return array(
+            array('content-5646847541564561', true),
+            array('node-5646847541564561', false),
+            array('node-content-5646847541564561', false),
+            array('', false),
+            array('content-nodezùzdeldze', true),
+        );
+    }
+
+    /**
      * Test extract
      */
     public function testExtractReference()
@@ -102,5 +131,37 @@ class ExtractReferenceFromContentStrategyTest extends AbstractBaseTestCase
         );
 
         $this->assertSame($expected, $this->strategy->extractReference($content));
+    }
+
+    /**
+     * @param string $reference
+     * @param mixed  $content
+     * @param int    $countTagManager
+     * @param string $expectedId
+     *
+     * @dataProvider provideReferenceAndContent
+     */
+    public function testInvalidateTagStatusableElement($reference, $content, $countTagManager, $expectedId)
+    {
+        Phake::when($this->contentRepository)->findById(Phake::anyParameters())->thenReturn($content);
+
+        $this->strategy->getInvalidateTagStatusableElement($reference);
+
+        Phake::verify($this->tagManager, Phake::times($countTagManager))->formatContentIdTag($expectedId);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideReferenceAndContent()
+    {
+        $content1 = Phake::mock('OpenOrchestra\ModelInterface\Model\ContentInterface');
+        $content1FakeId = 'fakeId';
+        Phake::when($content1)->getContentId()->thenReturn($content1FakeId);
+
+        return array(
+          array('content-54546465464', $content1, 1, $content1FakeId),
+          array('content-nonContent', null, 0, null)
+        );
     }
 }

--- a/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromNodeStrategyTest.php
+++ b/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromNodeStrategyTest.php
@@ -163,11 +163,11 @@ class ExtractReferenceFromNodeStrategyTest extends AbstractBaseTestCase
      *
      * @dataProvider provideReferenceAndNode
      */
-    public function testInvalidateTagStatusableElement($reference, $node, $countTagManager, $expectedId)
+    public function testGetStatusableElementCacheTag($reference, $node, $countTagManager, $expectedId)
     {
         Phake::when($this->nodeRepository)->findVersionByDocumentId(Phake::anyParameters())->thenReturn($node);
 
-        $this->strategy->getInvalidateTagStatusableElement($reference);
+        $this->strategy->getStatusableElementCacheTag($reference);
 
         Phake::verify($this->tagManager, Phake::times($countTagManager))->formatNodeIdTag($expectedId);
     }

--- a/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromNodeStrategyTest.php
+++ b/MediaAdminBundle/Tests/ExtractReference/Strategies/ExtractReferenceFromNodeStrategyTest.php
@@ -16,8 +16,9 @@ class ExtractReferenceFromNodeStrategyTest extends AbstractBaseTestCase
      * @var ExtractReferenceFromNodeStrategy
      */
     protected $strategy;
-
     protected $parserBBcode;
+    protected $tagManager;
+    protected $nodeRepository;
 
     /**
      * Set up the test
@@ -27,7 +28,10 @@ class ExtractReferenceFromNodeStrategyTest extends AbstractBaseTestCase
         $this->parserBBcode = Phake::mock('OpenOrchestra\BBcodeBundle\Parser\BBcodeParserInterface');
         Phake::when($this->parserBBcode)->parse(Phake::anyParameters())->thenReturn($this->parserBBcode);
 
-        $this->strategy = new ExtractReferenceFromNodeStrategy($this->parserBBcode);
+        $this->tagManager = Phake::mock('OpenOrchestra\BaseBundle\Manager\TagManager');
+        $this->nodeRepository = Phake::mock('OpenOrchestra\ModelInterface\Repository\NodeRepositoryInterface');
+
+        $this->strategy = new ExtractReferenceFromNodeStrategy($this->parserBBcode, $this->tagManager, $this->nodeRepository);
     }
 
     /**
@@ -61,6 +65,31 @@ class ExtractReferenceFromNodeStrategyTest extends AbstractBaseTestCase
             array('OpenOrchestra\ModelInterface\Model\NodeInterface', true),
             array('OpenOrchestra\ModelInterface\Model\ContentInterface', false),
             array('OpenOrchestra\ModelInterface\Model\StatusableInterface', false),
+        );
+    }
+
+    /**
+     * @param string $reference
+     * @param bool   $support
+     *
+     * @dataProvider provideReferenceAndSupport
+     */
+    public function testSupportReference($reference, $support)
+    {
+        $this->assertSame($support, $this->strategy->supportReference($reference));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideReferenceAndSupport()
+    {
+        return array(
+            array('content-5646847541564561', false),
+            array('node-5646847541564561', true),
+            array('node-content-5646847541564561', true),
+            array('', false),
+            array('content-nodezùzdeldze', false),
         );
     }
 
@@ -124,6 +153,38 @@ class ExtractReferenceFromNodeStrategyTest extends AbstractBaseTestCase
         );
 
         $this->assertSame($expected, $this->strategy->extractReference($node));
+    }
+
+    /**
+     * @param string $reference
+     * @param mixed  $node
+     * @param int    $countTagManager
+     * @param string $expectedId
+     *
+     * @dataProvider provideReferenceAndNode
+     */
+    public function testInvalidateTagStatusableElement($reference, $node, $countTagManager, $expectedId)
+    {
+        Phake::when($this->nodeRepository)->findVersionByDocumentId(Phake::anyParameters())->thenReturn($node);
+
+        $this->strategy->getInvalidateTagStatusableElement($reference);
+
+        Phake::verify($this->tagManager, Phake::times($countTagManager))->formatNodeIdTag($expectedId);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideReferenceAndNode()
+    {
+        $node = Phake::mock('OpenOrchestra\ModelInterface\Model\NodeInterface');
+        $nodeFakeId = 'fakeId';
+        Phake::when($node)->getNodeId()->thenReturn($nodeFakeId);
+
+        return array(
+            array('content-54546465464', $node, 1, $nodeFakeId),
+            array('content-nonContent', null, 0, null)
+        );
     }
 
     /**


### PR DESCRIPTION
[OO-FEATURE] Invalidate the cache tag of contents and nodes when update a media which they use it

https://github.com/open-orchestra/open-orchestra-model-bundle/pull/632
https://github.com/open-orchestra/open-orchestra-model-interface/pull/216
https://github.com/open-orchestra/open-orchestra-media-admin-bundle/pull/277
